### PR TITLE
fix: residual Dependabot bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "overrides": {
       "@babel/core": "^7.29.6",
       "@babel/plugin-transform-modules-systemjs": "^7.29.4",
-      "@isaacs/brace-expansion": "^5.0.1",
+      "@isaacs/brace-expansion": "^5.0.8",
       "brace-expansion": "^5.0.6",
       "decompress": "npm:@xhmikosr/decompress@^11.1.3",
       "dompurify": "^3.4.12",
@@ -84,10 +84,10 @@
       "next": "^16.2.6",
       "picomatch": "^4.0.4",
       "picomatch@2": "^2.3.2",
-      "postcss": "^8.5.10",
+      "postcss": "^8.5.19",
       "prismjs": "^1.30.0",
       "rollup": "^4.59.0",
-      "tar": "^7.5.16",
+      "tar": "^7.5.21",
       "undici": "^7.28.0",
       "uuid": "^13.0.1",
       "vite": "^7.3.5",
@@ -97,7 +97,8 @@
       "adm-zip": "^0.6.0",
       "brace-expansion@^1": "^1.1.16",
       "brace-expansion@^2": "^2.1.2",
-      "brace-expansion@^5": "^5.0.7"
+      "brace-expansion@^5": "^5.0.8",
+      "valibot": "^1.4.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@babel/core': ^7.29.6
   '@babel/plugin-transform-modules-systemjs': ^7.29.4
-  '@isaacs/brace-expansion': ^5.0.1
+  '@isaacs/brace-expansion': ^5.0.8
   brace-expansion: ^5.0.6
   decompress: npm:@xhmikosr/decompress@^11.1.3
   dompurify: ^3.4.12
@@ -26,10 +26,10 @@ overrides:
   next: ^16.2.6
   picomatch: ^4.0.4
   picomatch@2: ^2.3.2
-  postcss: ^8.5.10
+  postcss: ^8.5.19
   prismjs: ^1.30.0
   rollup: ^4.59.0
-  tar: ^7.5.16
+  tar: ^7.5.21
   undici: ^7.28.0
   uuid: ^13.0.1
   vite: ^7.3.5
@@ -39,7 +39,8 @@ overrides:
   adm-zip: ^0.6.0
   brace-expansion@^1: ^1.1.16
   brace-expansion@^2: ^2.1.2
-  brace-expansion@^5: ^5.0.7
+  brace-expansion@^5: ^5.0.8
+  valibot: ^1.4.2
 
 importers:
 
@@ -97,7 +98,7 @@ importers:
         specifier: ^0.485.0
         version: 0.485.0(react@19.2.4)
       next:
-        specifier: ^16.2.12
+        specifier: ^16.2.6
         version: 16.2.12(@babel/core@7.29.7)(@types/node@20.19.37)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-sanity:
         specifier: ^9.12.3
@@ -5369,11 +5370,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -5709,10 +5705,6 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -6447,8 +6439,8 @@ packages:
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
-  tar@7.5.17:
-    resolution: {integrity: sha512-wPEBwzapC+2PaTYPH6e2L+cNOEE227S47wUYFqlegcs8zlLLmeb9Fcff1HVZY4Fwku/1Eyv38n7GYwB2aaS71g==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -6761,8 +6753,8 @@ packages:
     resolution: {integrity: sha512-jjRGChg03uGp9f6wQYSO8qXkweJwRbA5WRuEQE8xLIiehIzIIi23qZSzsyvZPCPoFqkeLtZuz7Plt1LGukAInA==}
     hasBin: true
 
-  valibot@1.3.1:
-    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -9389,7 +9381,7 @@ snapshots:
       p-queue: 2.4.2
       rimraf: 6.1.3
       split2: 4.2.0
-      tar: 7.5.17
+      tar: 7.5.22
       yaml: 2.8.3
     transitivePeerDependencies:
       - '@types/react'
@@ -9715,7 +9707,7 @@ snapshots:
     dependencies:
       '@sanity/client': 7.20.0(debug@4.4.3)
       '@sanity/visual-editing-types': 1.1.8(@sanity/client@7.20.0(debug@4.4.3))(@sanity/types@3.99.0(@types/react@19.2.14)(debug@4.4.3))
-      valibot: 1.3.1(typescript@5.9.3)
+      valibot: 1.4.2(typescript@5.9.3)
     transitivePeerDependencies:
       - '@sanity/types'
       - typescript
@@ -9904,7 +9896,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
-      postcss: 8.5.15
+      postcss: 8.5.23
       tailwindcss: 4.2.2
 
   '@tanstack/react-table@8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
@@ -12624,8 +12616,6 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@3.3.15: {}
-
   nanoid@3.3.16: {}
 
   nanoid@5.1.7: {}
@@ -13012,12 +13002,6 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.15
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:
@@ -13963,7 +13947,7 @@ snapshots:
       '@types/stylis': 4.2.7
       css-to-react-native: 3.2.0
       csstype: 3.2.3
-      postcss: 8.5.15
+      postcss: 8.5.23
       react: 19.2.4
       shallowequal: 1.1.0
       stylis: 4.3.6
@@ -14046,7 +14030,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.17:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -14380,7 +14364,7 @@ snapshots:
 
   uuidv7@0.4.4: {}
 
-  valibot@1.3.1(typescript@5.9.3):
+  valibot@1.4.2(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 
@@ -14409,7 +14393,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.23
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/studio/package.json
+++ b/studio/package.json
@@ -39,9 +39,9 @@
     "overrides": {
       "@babel/core": "^7.29.6",
       "@babel/plugin-transform-modules-systemjs": "^7.29.4",
-      "@isaacs/brace-expansion": "^5.0.1",
+      "@isaacs/brace-expansion": "^5.0.8",
       "brace-expansion": "^5.0.6",
-      "dompurify": "^3.4.11",
+      "dompurify": "^3.4.12",
       "flatted": "^3.4.2",
       "follow-redirects": "^1.16.0",
       "form-data": "^4.0.6",
@@ -56,7 +56,7 @@
       "minimatch@3": "^3.1.3",
       "picomatch": "^4.0.4",
       "picomatch@2": "^2.3.2",
-      "postcss": "^8.5.10",
+      "postcss": "^8.5.19",
       "prismjs": "^1.30.0",
       "rollup": "^4.59.0",
       "tar": "^7.5.16",
@@ -64,7 +64,9 @@
       "uuid": "^13.0.1",
       "vite": "^7.3.5",
       "ws": "^8.21.0",
-      "yaml": "^2.8.3"
+      "yaml": "^2.8.3",
+      "adm-zip": "^0.6.0",
+      "brace-expansion@^5": "^5.0.8"
     }
   }
 }

--- a/studio/pnpm-lock.yaml
+++ b/studio/pnpm-lock.yaml
@@ -7,9 +7,9 @@ settings:
 overrides:
   '@babel/core': ^7.29.6
   '@babel/plugin-transform-modules-systemjs': ^7.29.4
-  '@isaacs/brace-expansion': ^5.0.1
+  '@isaacs/brace-expansion': ^5.0.8
   brace-expansion: ^5.0.6
-  dompurify: ^3.4.11
+  dompurify: ^3.4.12
   flatted: ^3.4.2
   follow-redirects: ^1.16.0
   form-data: ^4.0.6
@@ -24,7 +24,7 @@ overrides:
   minimatch@3: ^3.1.3
   picomatch: ^4.0.4
   picomatch@2: ^2.3.2
-  postcss: ^8.5.10
+  postcss: ^8.5.19
   prismjs: ^1.30.0
   rollup: ^4.59.0
   tar: ^7.5.16
@@ -33,6 +33,8 @@ overrides:
   vite: ^7.3.5
   ws: ^8.21.0
   yaml: ^2.8.3
+  adm-zip: ^0.6.0
+  brace-expansion@^5: ^5.0.8
 
 importers:
 
@@ -2222,9 +2224,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.16:
-    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -2415,6 +2417,10 @@ packages:
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2790,8 +2796,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3959,6 +3965,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@5.1.6:
     resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
     engines: {node: ^18 || >=20}
@@ -4226,8 +4237,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   preferred-pm@4.1.1:
@@ -7174,7 +7185,7 @@ snapshots:
 
   '@sanity/bifur-client@0.4.1':
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.15
       rxjs: 7.8.2
 
   '@sanity/blueprints-parser@0.3.0': {}
@@ -7479,7 +7490,7 @@ snapshots:
       '@sanity/blueprints': 0.7.0
       '@sanity/blueprints-parser': 0.3.0
       '@sanity/client': 7.13.2(debug@4.4.3)
-      adm-zip: 0.5.16
+      adm-zip: 0.6.0
       array-treeify: 0.1.5
       cardinal: 2.1.1
       chalk: 5.6.2
@@ -7959,7 +7970,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  adm-zip@0.5.16: {}
+  adm-zip@0.6.0: {}
 
   agent-base@7.1.4: {}
 
@@ -8158,6 +8169,10 @@ snapshots:
   boolbase@1.0.0: {}
 
   brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
+
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8541,7 +8556,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -9493,7 +9508,7 @@ snapshots:
 
   isomorphic-dompurify@2.26.0:
     dependencies:
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       jsdom: 26.1.0
     transitivePeerDependencies:
       - bufferutil
@@ -9775,7 +9790,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
@@ -9840,6 +9855,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@3.3.15: {}
+
+  nanoid@3.3.16: {}
 
   nanoid@5.1.6: {}
 
@@ -10126,9 +10143,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.16:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -10964,7 +10981,7 @@ snapshots:
       '@types/stylis': 4.2.5
       css-to-react-native: 3.2.0
       csstype: 3.1.3
-      postcss: 8.5.16
+      postcss: 8.5.23
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       shallowequal: 1.1.0
@@ -11279,7 +11296,7 @@ snapshots:
       esbuild: 0.27.0
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.23
       rollup: 4.62.2
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Override tar/postcss/brace-expansion/valibot/adm-zip to patched versions


Made with [Cursor](https://cursor.com)