### PR TITLE
fix(deps): bump brace-expansion override to ^5.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
       "@babel/core": "^7.29.6",
       "@babel/plugin-transform-modules-systemjs": "^7.29.4",
       "@isaacs/brace-expansion": "^5.0.8",
-      "brace-expansion": "^5.0.6",
+      "brace-expansion": "^5.0.8",
       "decompress": "npm:@xhmikosr/decompress@^11.1.3",
       "dompurify": "^3.4.12",
       "flatted": "^3.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@babel/core': ^7.29.6
   '@babel/plugin-transform-modules-systemjs': ^7.29.4
   '@isaacs/brace-expansion': ^5.0.8
-  brace-expansion: ^5.0.6
+  brace-expansion: ^5.0.8
   decompress: npm:@xhmikosr/decompress@^11.1.3
   dompurify: ^3.4.12
   flatted: ^3.4.2

--- a/studio/package.json
+++ b/studio/package.json
@@ -40,7 +40,7 @@
       "@babel/core": "^7.29.6",
       "@babel/plugin-transform-modules-systemjs": "^7.29.4",
       "@isaacs/brace-expansion": "^5.0.8",
-      "brace-expansion": "^5.0.6",
+      "brace-expansion": "^5.0.8",
       "dompurify": "^3.4.12",
       "flatted": "^3.4.2",
       "follow-redirects": "^1.16.0",

--- a/studio/pnpm-lock.yaml
+++ b/studio/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@babel/core': ^7.29.6
   '@babel/plugin-transform-modules-systemjs': ^7.29.4
   '@isaacs/brace-expansion': ^5.0.8
-  brace-expansion: ^5.0.6
+  brace-expansion: ^5.0.8
   dompurify: ^3.4.12
   flatted: ^3.4.2
   follow-redirects: ^1.16.0
@@ -2413,10 +2413,6 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -8168,10 +8164,6 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@5.0.7:
-    dependencies:
-      balanced-match: 4.0.4
-
   brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
@@ -9794,7 +9786,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist-options@4.1.0:
     dependencies:


### PR DESCRIPTION
Closes Dependabot high alert on studio lockfile brace-expansion.

Made with [Cursor](https://cursor.com)