### PR TITLE
chore(deps): bump DomPurify, js-yaml, and nanoid overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,12 +64,12 @@
       "@isaacs/brace-expansion": "^5.0.1",
       "brace-expansion": "^5.0.9",
       "decompress": "npm:@xhmikosr/decompress@^11.1.3",
-      "dompurify": "^3.4.12",
+      "dompurify": "^3.4.13",
       "flatted": "^3.4.2",
       "follow-redirects": "^1.16.0",
       "form-data": "^4.0.6",
       "glob": "^10.5.0",
-      "js-yaml": "^4.2.0",
+      "js-yaml": "^4.3.1",
       "json-2-csv": "^5.5.11",
       "linkify-it": "^5.0.1",
       "lodash": "^4.18.0",
@@ -95,7 +95,10 @@
       "brace-expansion@^2": "^2.1.4",
       "brace-expansion@^5": "^5.0.9",
       "valibot": "^1.4.2",
-      "fast-uri": "^3.1.5"
+      "fast-uri": "^3.1.5",
+      "nanoid@^3": "^3.3.17",
+      "nanoid@^5": "^5.1.16",
+      "nanoid@^4": "5.1.16"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,12 +10,12 @@ overrides:
   '@isaacs/brace-expansion': ^5.0.1
   brace-expansion: ^5.0.9
   decompress: npm:@xhmikosr/decompress@^11.1.3
-  dompurify: ^3.4.12
+  dompurify: ^3.4.13
   flatted: ^3.4.2
   follow-redirects: ^1.16.0
   form-data: ^4.0.6
   glob: ^10.5.0
-  js-yaml: ^4.2.0
+  js-yaml: ^4.3.1
   json-2-csv: ^5.5.11
   linkify-it: ^5.0.1
   lodash: ^4.18.0
@@ -42,6 +42,9 @@ overrides:
   brace-expansion@^5: ^5.0.9
   valibot: ^1.4.2
   fast-uri: ^3.1.5
+  nanoid@^3: ^3.3.17
+  nanoid@^5: ^5.1.16
+  nanoid@^4: 5.1.16
 
 importers:
 
@@ -3764,8 +3767,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4686,8 +4689,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom-global@3.0.2:
@@ -5110,18 +5113,13 @@ packages:
     resolution: {integrity: sha512-zoTNyBafxG0+F5PP3T3j1PKMr7gedriSdYRhLFLRFCz0OnQfQ6BkVk9peXVF30hz633Bw0Zh5McleOrXPjWYCQ==}
     engines: {node: '>=18'}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@5.1.7:
-    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -8939,7 +8937,7 @@ snapshots:
 
   '@sanity/bifur-client@0.4.1':
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       rxjs: 7.8.2
 
   '@sanity/cli@3.99.0(@types/node@20.19.37)(@types/react@19.2.14)(lightningcss@1.32.0)(react@19.2.4)(typescript@5.9.3)(yaml@2.8.3)':
@@ -8995,7 +8993,7 @@ snapshots:
     dependencies:
       '@sanity/eventsource': 5.0.2
       get-it: 8.7.0(debug@4.4.3)
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
@@ -9174,7 +9172,7 @@ snapshots:
       hotscript: 1.0.13
       lodash: 4.18.1
       mendoza: 3.0.8
-      nanoid: 5.1.7
+      nanoid: 5.1.16
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
@@ -10558,7 +10556,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -11611,7 +11609,7 @@ snapshots:
 
   isomorphic-dompurify@2.36.0:
     dependencies:
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       jsdom: 28.1.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -11643,7 +11641,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -11738,7 +11736,7 @@ snapshots:
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.49.0
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       html2canvas: 1.4.1
 
   jsx-ast-utils@3.3.5:
@@ -11845,7 +11843,7 @@ snapshots:
   load-yaml-file@0.2.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -12070,11 +12068,9 @@ snapshots:
 
   nano-pubsub@3.0.0: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.18: {}
 
-  nanoid@3.3.16: {}
-
-  nanoid@5.1.7: {}
+  nanoid@5.1.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -12453,7 +12449,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12961,7 +12957,7 @@ snapshots:
       mendoza: 3.0.8
       module-alias: 2.3.4
       nano-pubsub: 3.0.0
-      nanoid: 3.3.11
+      nanoid: 3.3.18
       node-html-parser: 6.1.13
       observable-callback: 1.0.3(rxjs@7.8.2)
       oneline: 1.0.4

--- a/studio/package.json
+++ b/studio/package.json
@@ -41,12 +41,12 @@
       "@babel/plugin-transform-modules-systemjs": "^7.29.4",
       "@isaacs/brace-expansion": "^5.0.1",
       "brace-expansion": "^5.0.9",
-      "dompurify": "^3.4.12",
+      "dompurify": "^3.4.13",
       "flatted": "^3.4.2",
       "follow-redirects": "^1.16.0",
       "form-data": "^4.0.6",
       "glob": "^10.5.0",
-      "js-yaml": "^4.2.0",
+      "js-yaml": "^4.3.1",
       "json-2-csv": "^5.5.11",
       "linkify-it": "^5.0.1",
       "lodash": "^4.18.0",
@@ -71,7 +71,10 @@
       "brace-expansion@^2": "^2.1.4",
       "fast-uri": "^3.1.5",
       "ajv@^6": "^6.14.0",
-      "ajv@^8": "^8.17.1"
+      "ajv@^8": "^8.17.1",
+      "nanoid@^3": "^3.3.17",
+      "nanoid@^5": "^5.1.16",
+      "nanoid@^4": "5.1.16"
     }
   }
 }

--- a/studio/pnpm-lock.yaml
+++ b/studio/pnpm-lock.yaml
@@ -9,12 +9,12 @@ overrides:
   '@babel/plugin-transform-modules-systemjs': ^7.29.4
   '@isaacs/brace-expansion': ^5.0.1
   brace-expansion: ^5.0.9
-  dompurify: ^3.4.12
+  dompurify: ^3.4.13
   flatted: ^3.4.2
   follow-redirects: ^1.16.0
   form-data: ^4.0.6
   glob: ^10.5.0
-  js-yaml: ^4.2.0
+  js-yaml: ^4.3.1
   json-2-csv: ^5.5.11
   linkify-it: ^5.0.1
   lodash: ^4.18.0
@@ -40,6 +40,9 @@ overrides:
   fast-uri: ^3.1.5
   ajv@^6: ^6.14.0
   ajv@^8: ^8.17.1
+  nanoid@^3: ^3.3.17
+  nanoid@^5: ^5.1.16
+  nanoid@^4: 5.1.16
 
 importers:
 
@@ -2801,8 +2804,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -3642,8 +3645,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom-global@3.0.2:
@@ -3960,23 +3963,13 @@ packages:
     resolution: {integrity: sha512-zoTNyBafxG0+F5PP3T3j1PKMr7gedriSdYRhLFLRFCz0OnQfQ6BkVk9peXVF30hz633Bw0Zh5McleOrXPjWYCQ==}
     engines: {node: '>=18'}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -6489,7 +6482,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -7190,7 +7183,7 @@ snapshots:
 
   '@sanity/bifur-client@0.4.1':
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.18
       rxjs: 7.8.2
 
   '@sanity/blueprints-parser@0.3.0': {}
@@ -7239,7 +7232,7 @@ snapshots:
     dependencies:
       '@sanity/eventsource': 5.0.2
       get-it: 8.7.0(debug@4.4.3)
-      nanoid: 3.3.11
+      nanoid: 3.3.18
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
@@ -7429,7 +7422,7 @@ snapshots:
       hotscript: 1.0.13
       lodash: 4.18.1
       mendoza: 3.0.8
-      nanoid: 5.1.6
+      nanoid: 5.1.16
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
@@ -7442,7 +7435,7 @@ snapshots:
       hotscript: 1.0.13
       lodash: 4.18.1
       mendoza: 3.0.8
-      nanoid: 5.1.6
+      nanoid: 5.1.16
       rxjs: 7.8.2
     transitivePeerDependencies:
       - debug
@@ -8564,7 +8557,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -9516,7 +9509,7 @@ snapshots:
 
   isomorphic-dompurify@2.26.0:
     dependencies:
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       jsdom: 26.1.0
     transitivePeerDependencies:
       - bufferutil
@@ -9549,7 +9542,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -9650,7 +9643,7 @@ snapshots:
   load-yaml-file@0.2.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       pify: 4.0.1
       strip-bom: 3.0.0
 
@@ -9860,13 +9853,9 @@ snapshots:
 
   nano-pubsub@3.0.0: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.18: {}
 
-  nanoid@3.3.15: {}
-
-  nanoid@3.3.16: {}
-
-  nanoid@5.1.6: {}
+  nanoid@5.1.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -10153,7 +10142,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -10626,7 +10615,7 @@ snapshots:
       module-alias: 2.2.3
       motion: 12.23.26(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nano-pubsub: 3.0.0
-      nanoid: 3.3.11
+      nanoid: 3.3.18
       node-html-parser: 6.1.13
       observable-callback: 1.0.3(rxjs@7.8.2)
       oneline: 1.0.4


### PR DESCRIPTION
## Summary
- Root + `studio/`: DomPurify `^3.4.13`, js-yaml `^4.3.1`, nanoid v3/v4/v5 overrides to patched floors.
- Refreshes both lockfiles.

## Test plan
- [x] `pnpm install` at root and in `studio/`
- [ ] Confirm Dependabot alerts #297–#306 close after merge

Made with [Cursor](https://cursor.com)